### PR TITLE
Fix darkice prefix in jack_capture command

### DIFF
--- a/stereo_recording.py
+++ b/stereo_recording.py
@@ -21,7 +21,7 @@ def start():
   else: 
     print("starting...")
     mysub = subprocess.Popen(["jack_capture", "--filename-prefix",
-    recording_path_prefix, "-S", "--channels", "2", "--port", "darkice*", "-as"])
+    recording_path_prefix, "-S", "--channels", "2", "--port", "darkice:*", "-as"])
     print("Recording started, process num: ", mysub.pid)
 
 def stop():


### PR DESCRIPTION
jack_capture wasn't finding the darkice channels, seems the port prefix with wildcard needs to go all the way to the `:` in the JACK port name. Changed the JACK darkice client name in darkice.config, which is now just `darkice` and then altered the jack_capture.